### PR TITLE
Add LargeXlsx to StringCells benchmarks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,7 @@
     <PackageVersion Include="DocumentFormat.OpenXml" Version="3.3.0" />
     <PackageVersion Include="EPPlusFree" Version="4.5.3.8" />
     <PackageVersion Include="ErrorProne.NET.Structs" Version="0.6.1-beta.1" />
+    <PackageVersion Include="LargeXlsx" Version="1.12.0" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />

--- a/SpreadCheetah.Benchmark.Test/Tests/StringCellsTests.cs
+++ b/SpreadCheetah.Benchmark.Test/Tests/StringCellsTests.cs
@@ -84,6 +84,17 @@ public sealed class StringCellsTests : IDisposable
         AssertCellValuesEqual();
     }
 
+    [Fact]
+    public void StringCells_LargeXlsx_CorrectCellValues()
+    {
+        // Act
+        _stringCells.LargeXlsx();
+
+        // Assert
+        WriteOutput();
+        AssertCellValuesEqual();
+    }
+
     private void WriteOutput()
     {
         _output.WriteLine("Stream length: " + _stringCells.Stream.Length);

--- a/SpreadCheetah.Benchmark/Benchmarks/StringCells.cs
+++ b/SpreadCheetah.Benchmark/Benchmarks/StringCells.cs
@@ -3,6 +3,7 @@ using ClosedXML.Excel;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
+using LargeXlsx;
 using OfficeOpenXml;
 using System.IO.Packaging;
 using OpenXmlCell = DocumentFormat.OpenXml.Spreadsheet.Cell;
@@ -212,5 +213,23 @@ public class StringCells : IDisposable
         }
 
         workbook.SaveAs(Stream);
+    }
+
+    [Benchmark]
+    public void LargeXlsx()
+    {
+        using var xlsxWriter = new XlsxWriter(Stream);
+        using var worksheet = xlsxWriter.BeginWorksheet(SheetName);
+
+        for (var row = 0; row < Values.Count; ++row)
+        {
+            worksheet.BeginRow();
+
+            var rowValues = Values[row];
+            for (var col = 0; col < rowValues.Count; ++col)
+            {
+                xlsxWriter.Write(rowValues[col]);
+            }
+        }
     }
 }

--- a/SpreadCheetah.Benchmark/SpreadCheetah.Benchmark.csproj
+++ b/SpreadCheetah.Benchmark/SpreadCheetah.Benchmark.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="ClosedXML" />
     <PackageReference Include="DocumentFormat.OpenXml" />
     <PackageReference Include="EPPlusFree" />
+    <PackageReference Include="LargeXlsx" />
     <PackageReference Include="System.Drawing.Common" />
     <PackageReference Include="System.Reflection.Metadata" />
   </ItemGroup>


### PR DESCRIPTION
- Adds a LargeXlsx implementation to the StringCells benchmark suite to compare forward-only spreadsheet writers focused on low memory usage for very large sheets.
- Implementation uses XlsxWriter with BeginWorksheet/BeginRow to stream rows, matching the pattern used by other contenders (SpreadCheetah, EPPlus, OpenXml SAX/DOM, ClosedXML).
- Results (local runs): LargeXlsx consistently places second for both throughput and managed allocations, trailing SpreadCheetah and ahead of EPPlus, OpenXml, and ClosedXML.
- Changes are limited to the benchmark project; includes a package reference to LargeXlsx.