### PR TITLE
R1C1 support

### DIFF
--- a/SpreadCheetah.Test/Tests/FormulaTests.cs
+++ b/SpreadCheetah.Test/Tests/FormulaTests.cs
@@ -65,4 +65,14 @@ public static class FormulaTests
         // Act & Assert
         Assert.Throws<ArgumentException>(() => Formula.Hyperlink(uri, friendlyName));
     }
+
+    [Fact]
+    public static void Formula_R1C1_NullFormula()
+    {
+        // Arrange
+        string formula = null!;
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => Formula.R1C1(formula));
+    }
 }

--- a/SpreadCheetah.Test/Tests/PublicApiTests.PublicApi_Generate.DotNet10_0.verified.txt
+++ b/SpreadCheetah.Test/Tests/PublicApiTests.PublicApi_Generate.DotNet10_0.verified.txt
@@ -69,6 +69,7 @@ namespace SpreadCheetah
         public Formula(string? formulaText) { }
         public static SpreadCheetah.Formula Hyperlink(System.Uri uri) { }
         public static SpreadCheetah.Formula Hyperlink(System.Uri uri, string friendlyName) { }
+        public static SpreadCheetah.Formula R1C1(string formula) { }
     }
     public enum SpreadCheetahCompressionLevel
     {

--- a/SpreadCheetah.Test/Tests/PublicApiTests.PublicApi_Generate.DotNet8_0.verified.txt
+++ b/SpreadCheetah.Test/Tests/PublicApiTests.PublicApi_Generate.DotNet8_0.verified.txt
@@ -68,6 +68,7 @@ namespace SpreadCheetah
         public Formula(string? formulaText) { }
         public static SpreadCheetah.Formula Hyperlink(System.Uri uri) { }
         public static SpreadCheetah.Formula Hyperlink(System.Uri uri, string friendlyName) { }
+        public static SpreadCheetah.Formula R1C1(string formula) { }
     }
     public enum SpreadCheetahCompressionLevel
     {

--- a/SpreadCheetah.Test/Tests/PublicApiTests.PublicApi_Generate.DotNet9_0.verified.txt
+++ b/SpreadCheetah.Test/Tests/PublicApiTests.PublicApi_Generate.DotNet9_0.verified.txt
@@ -68,6 +68,7 @@ namespace SpreadCheetah
         public Formula(string? formulaText) { }
         public static SpreadCheetah.Formula Hyperlink(System.Uri uri) { }
         public static SpreadCheetah.Formula Hyperlink(System.Uri uri, string friendlyName) { }
+        public static SpreadCheetah.Formula R1C1(string formula) { }
     }
     public enum SpreadCheetahCompressionLevel
     {

--- a/SpreadCheetah.Test/Tests/PublicApiTests.PublicApi_Generate.Net4_7.verified.txt
+++ b/SpreadCheetah.Test/Tests/PublicApiTests.PublicApi_Generate.Net4_7.verified.txt
@@ -67,6 +67,7 @@ namespace SpreadCheetah
         public Formula(string? formulaText) { }
         public static SpreadCheetah.Formula Hyperlink(System.Uri uri) { }
         public static SpreadCheetah.Formula Hyperlink(System.Uri uri, string friendlyName) { }
+        public static SpreadCheetah.Formula R1C1(string formula) { }
     }
     public enum SpreadCheetahCompressionLevel
     {

--- a/SpreadCheetah.Test/Tests/R1C1FormulaConverterTests.cs
+++ b/SpreadCheetah.Test/Tests/R1C1FormulaConverterTests.cs
@@ -1,0 +1,84 @@
+using SpreadCheetah.Formulas;
+
+namespace SpreadCheetah.Test.Tests;
+
+public static class R1C1FormulaConverterTests
+{
+    [Theory]
+    // Absolute cell references (independent of anchor)
+    [InlineData("R1C1", 1, 1, "$A$1")]
+    [InlineData("R5C3", 1, 1, "$C$5")]
+    [InlineData("R5C3", 9, 9, "$C$5")]
+    // Relative cell references (depend on anchor)
+    [InlineData("RC", 3, 2, "B3")]
+    [InlineData("RC[-1]", 3, 2, "A3")]
+    [InlineData("R[-1]C", 3, 2, "B2")]
+    [InlineData("R[1]C[1]", 3, 2, "C4")]
+    [InlineData("R[10]C[5]", 1, 1, "F11")]
+    // Mixed references
+    [InlineData("R1C[1]", 3, 2, "C$1")]
+    [InlineData("R[1]C1", 3, 2, "$A4")]
+    // Whole row references
+    [InlineData("R5", 3, 2, "$5:$5")]
+    [InlineData("R[2]", 3, 2, "5:5")]
+    [InlineData("R", 3, 2, "3:3")]
+    // Whole column references
+    [InlineData("C3", 3, 2, "$C:$C")]
+    [InlineData("C[-1]", 3, 2, "A:A")]
+    [InlineData("C", 3, 2, "B:B")]
+    // Ranges
+    [InlineData("R1C1:R2C2", 1, 1, "$A$1:$B$2")]
+    [InlineData("RC:R[1]C[1]", 3, 2, "B3:C4")]
+    [InlineData("R1:R3", 1, 1, "$1:$3")]
+    [InlineData("C1:C3", 1, 1, "$A:$C")]
+    public static void R1C1FormulaConverter_ToA1_Reference(string formula, int row, int column, string expected)
+    {
+        // Act
+        var actual = R1C1FormulaConverter.ToA1(formula, row, column);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("SUM(RC[-2]:RC[-1])", 1, 3, "SUM(A1:B1)")]
+    [InlineData("RC[-1]*RC[-2]", 5, 3, "B5*A5")]
+    [InlineData("IF(RC[-1]>0,\"Yes\",\"No\")", 2, 2, "IF(A2>0,\"Yes\",\"No\")")]
+    [InlineData("Sheet1!R1C1", 5, 5, "Sheet1!$A$1")]
+    [InlineData("'My Sheet'!RC[-1]", 3, 2, "'My Sheet'!A3")]
+    public static void R1C1FormulaConverter_ToA1_WithinExpression(string formula, int row, int column, string expected)
+    {
+        // Act
+        var actual = R1C1FormulaConverter.ToA1(formula, row, column);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    // Quoted text that looks like references must not be converted
+    [InlineData("\"RC[-1]\"", 1, 1, "\"RC[-1]\"")]
+    [InlineData("\"R1C1\"", 1, 1, "\"R1C1\"")]
+    // Function names and identifiers containing R/C must not be converted
+    [InlineData("ROUND(RC[-1],2)", 1, 3, "ROUND(B1,2)")]
+    [InlineData("COUNT(RC)", 2, 2, "COUNT(B2)")]
+    public static void R1C1FormulaConverter_ToA1_DoesNotConvertNonReferences(string formula, int row, int column, string expected)
+    {
+        // Act
+        var actual = R1C1FormulaConverter.ToA1(formula, row, column);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("RC[-1]", 1, 1)] // Column 0 does not exist
+    [InlineData("R[-1]C", 1, 1)] // Row 0 does not exist
+    [InlineData("RC[1]", 1, 16384)] // Beyond last column
+    [InlineData("R[1]C", 1048576, 1)] // Beyond last row
+    public static void R1C1FormulaConverter_ToA1_OutOfBoundsThrows(string formula, int row, int column)
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => R1C1FormulaConverter.ToA1(formula, row, column));
+    }
+}

--- a/SpreadCheetah.Test/Tests/R1C1FormulaConverterTests.cs
+++ b/SpreadCheetah.Test/Tests/R1C1FormulaConverterTests.cs
@@ -15,9 +15,16 @@ public static class R1C1FormulaConverterTests
     [InlineData("R[-1]C", 3, 2, "B2")]
     [InlineData("R[1]C[1]", 3, 2, "C4")]
     [InlineData("R[10]C[5]", 1, 1, "F11")]
+    // Explicit plus sign in relative offset
+    [InlineData("R[+1]C[+1]", 3, 2, "C4")]
+    // Lowercase r/c are treated the same as uppercase
+    [InlineData("rc[-1]", 3, 2, "A3")]
+    [InlineData("r1c1", 1, 1, "$A$1")]
     // Mixed references
     [InlineData("R1C[1]", 3, 2, "C$1")]
     [InlineData("R[1]C1", 3, 2, "$A4")]
+    // Column names beyond 'Z'
+    [InlineData("R1C27", 1, 1, "$AA$1")]
     // Whole row references
     [InlineData("R5", 3, 2, "$5:$5")]
     [InlineData("R[2]", 3, 2, "5:5")]
@@ -46,6 +53,13 @@ public static class R1C1FormulaConverterTests
     [InlineData("IF(RC[-1]>0,\"Yes\",\"No\")", 2, 2, "IF(A2>0,\"Yes\",\"No\")")]
     [InlineData("Sheet1!R1C1", 5, 5, "Sheet1!$A$1")]
     [InlineData("'My Sheet'!RC[-1]", 3, 2, "'My Sheet'!A3")]
+    // Escaped single quote inside a quoted sheet name
+    [InlineData("'O''Brien'!R1C1", 5, 5, "'O''Brien'!$A$1")]
+    // An unquoted sheet name that itself looks like a reference must be left intact
+    [InlineData("C5!RC[-1]", 3, 2, "C5!A3")]
+    // A reference followed by ':' but not by another reference is not turned into a range
+    [InlineData("R1C1:", 1, 1, "$A$1:")]
+    [InlineData("R1C1:foo", 1, 1, "$A$1:foo")]
     public static void R1C1FormulaConverter_ToA1_WithinExpression(string formula, int row, int column, string expected)
     {
         // Act
@@ -56,12 +70,22 @@ public static class R1C1FormulaConverterTests
     }
 
     [Theory]
+    [InlineData("", 1, 1, "")]
     // Quoted text that looks like references must not be converted
     [InlineData("\"RC[-1]\"", 1, 1, "\"RC[-1]\"")]
     [InlineData("\"R1C1\"", 1, 1, "\"R1C1\"")]
+    // Escaped double quotes inside a string literal
+    [InlineData("\"Total \"\"RC\"\" here\"", 1, 1, "\"Total \"\"RC\"\" here\"")]
+    // Unterminated string literal is left as-is
+    [InlineData("\"unterminated", 1, 1, "\"unterminated")]
     // Function names and identifiers containing R/C must not be converted
     [InlineData("ROUND(RC[-1],2)", 1, 3, "ROUND(B1,2)")]
     [InlineData("COUNT(RC)", 2, 2, "COUNT(B2)")]
+    // An R/C that is part of a longer identifier must not be converted
+    [InlineData("FooR1C1", 1, 1, "FooR1C1")]
+    // Malformed references are passed through unchanged
+    [InlineData("R[1", 3, 2, "R[1")]
+    [InlineData("RC[", 3, 2, "RC[")]
     public static void R1C1FormulaConverter_ToA1_DoesNotConvertNonReferences(string formula, int row, int column, string expected)
     {
         // Act
@@ -76,6 +100,8 @@ public static class R1C1FormulaConverterTests
     [InlineData("R[-1]C", 1, 1)] // Row 0 does not exist
     [InlineData("RC[1]", 1, 16384)] // Beyond last column
     [InlineData("R[1]C", 1048576, 1)] // Beyond last row
+    [InlineData("R1C16385", 1, 1)] // Absolute column beyond the maximum
+    [InlineData("R10000000C1", 1, 1)] // Absolute row beyond the maximum (number overflow cap)
     public static void R1C1FormulaConverter_ToA1_OutOfBoundsThrows(string formula, int row, int column)
     {
         // Act & Assert

--- a/SpreadCheetah.Test/Tests/R1C1FormulaConverterTests.cs
+++ b/SpreadCheetah.Test/Tests/R1C1FormulaConverterTests.cs
@@ -105,6 +105,6 @@ public static class R1C1FormulaConverterTests
     public static void R1C1FormulaConverter_ToA1_OutOfBoundsThrows(string formula, int row, int column)
     {
         // Act & Assert
-        Assert.Throws<ArgumentException>(() => R1C1FormulaConverter.ToA1(formula, row, column));
+        Assert.Throws<SpreadCheetahException>(() => R1C1FormulaConverter.ToA1(formula, row, column));
     }
 }

--- a/SpreadCheetah.Test/Tests/SpreadsheetFormulaRowTests.cs
+++ b/SpreadCheetah.Test/Tests/SpreadsheetFormulaRowTests.cs
@@ -750,4 +750,59 @@ public class SpreadsheetFormulaRowTests
         using var sheet = SpreadsheetAssert.SingleSheet(stream);
         Assert.Equal(""""""HYPERLINK("https://github.com/","""Link to ""GitHub""""")"""""", sheet["A1"].Formula);
     }
+
+    [Theory]
+    [InlineData("R1C1", "$A$1")]
+    [InlineData("RC[-1]", "B1")]
+    [InlineData("SUM(R1C1:R3C1)", "SUM($A$1:$A$3)")]
+    [InlineData("RC[-1]*RC[-2]", "B1*A1")]
+    public async Task Spreadsheet_AddRow_CellWithR1C1Formula(string r1c1, string expectedA1)
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        await using (var spreadsheet = await Spreadsheet.CreateNewAsync(stream, cancellationToken: Token))
+        {
+            await spreadsheet.StartWorksheetAsync("Sheet", token: Token);
+
+            // The formula cell is placed in column C (3), so it acts as the anchor for relative references.
+            var cells = new[] { new Cell(1), new Cell(2), new Cell(Formula.R1C1(r1c1)) };
+
+            // Act
+            await spreadsheet.AddRowAsync(cells, Token);
+            await spreadsheet.FinishAsync(Token);
+        }
+
+        // Assert
+        SpreadsheetAssert.Valid(stream);
+        using var workbook = new XLWorkbook(stream);
+        var worksheet = workbook.Worksheets.Single();
+        var actualCell = worksheet.Cell(1, 3);
+        Assert.Equal(expectedA1, actualCell.FormulaA1);
+    }
+
+    [Fact]
+    public async Task Spreadsheet_AddRow_SameR1C1FormulaConvertedPerRow()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        var formula = Formula.R1C1("RC[-1]*RC[-2]");
+        await using (var spreadsheet = await Spreadsheet.CreateNewAsync(stream, cancellationToken: Token))
+        {
+            await spreadsheet.StartWorksheetAsync("Sheet", token: Token);
+
+            // Act
+            for (var i = 0; i < 3; i++)
+                await spreadsheet.AddRowAsync([new Cell(1), new Cell(2), new Cell(formula)], Token);
+
+            await spreadsheet.FinishAsync(Token);
+        }
+
+        // Assert
+        SpreadsheetAssert.Valid(stream);
+        using var workbook = new XLWorkbook(stream);
+        var worksheet = workbook.Worksheets.Single();
+        Assert.Equal("B1*A1", worksheet.Cell(1, 3).FormulaA1);
+        Assert.Equal("B2*A2", worksheet.Cell(2, 3).FormulaA1);
+        Assert.Equal("B3*A3", worksheet.Cell(3, 3).FormulaA1);
+    }
 }

--- a/SpreadCheetah/CellWriters/CellWithReferenceWriter.cs
+++ b/SpreadCheetah/CellWriters/CellWithReferenceWriter.cs
@@ -15,7 +15,7 @@ internal sealed class CellWithReferenceWriter : ICellWriter<Cell>
         var writer = CellValueWriter.GetWriter(cell.DataCell.Type);
         return cell switch
         {
-            { Formula: { } f } => writer.TryWriteCellWithReference(f.FormulaText, cell.DataCell, cell.StyleId, state),
+            { Formula: { } f } => writer.TryWriteCellWithReference(f.GetFormulaText(state), cell.DataCell, cell.StyleId, state),
             { StyleId: not null } => writer.TryWriteCellWithReference(cell.DataCell, cell.StyleId, state),
             _ => writer.TryWriteCellWithReference(cell.DataCell, state)
         };
@@ -26,7 +26,7 @@ internal sealed class CellWithReferenceWriter : ICellWriter<Cell>
         var actualStyleId = cell.StyleId ?? styleId;
         var writer = CellValueWriter.GetWriter(cell.DataCell.Type);
         return cell.Formula is { } formula
-            ? writer.TryWriteCellWithReference(formula.FormulaText, cell.DataCell, actualStyleId, state)
+            ? writer.TryWriteCellWithReference(formula.GetFormulaText(state), cell.DataCell, actualStyleId, state)
             : writer.TryWriteCellWithReference(cell.DataCell, actualStyleId, state);
     }
 
@@ -50,7 +50,7 @@ internal sealed class CellWithReferenceWriter : ICellWriter<Cell>
     public bool TryWriteValue(in Cell cell, ref int valueIndex, CellWriterState state)
     {
         return cell.Formula is { } formula
-            ? FormulaCellHelper.FinishWritingFormulaCellValue(cell, formula.FormulaText, ref valueIndex, state.Buffer)
+            ? FormulaCellHelper.FinishWritingFormulaCellValue(cell, formula.GetFormulaText(state), ref valueIndex, state.Buffer)
             : CellValueWriter.GetWriter(cell.DataCell.Type).WriteValuePieceByPiece(cell.DataCell, state.Buffer, ref valueIndex);
     }
 

--- a/SpreadCheetah/CellWriters/CellWriter.cs
+++ b/SpreadCheetah/CellWriters/CellWriter.cs
@@ -15,7 +15,7 @@ internal sealed class CellWriter : ICellWriter<Cell>
         var writer = CellValueWriter.GetWriter(cell.DataCell.Type);
         return cell switch
         {
-            { Formula: { } formula } => writer.TryWriteCell(formula.FormulaText, cell.DataCell, cell.StyleId, state),
+            { Formula: { } formula } => writer.TryWriteCell(formula.GetFormulaText(state), cell.DataCell, cell.StyleId, state),
             { StyleId: not null } => writer.TryWriteCell(cell.DataCell, cell.StyleId, state.Buffer),
             _ => writer.TryWriteCell(cell.DataCell, state)
         };
@@ -26,7 +26,7 @@ internal sealed class CellWriter : ICellWriter<Cell>
         var actualStyleId = cell.StyleId ?? styleId;
         var writer = CellValueWriter.GetWriter(cell.DataCell.Type);
         return cell.Formula is { } formula
-            ? writer.TryWriteCell(formula.FormulaText, cell.DataCell, actualStyleId, state)
+            ? writer.TryWriteCell(formula.GetFormulaText(state), cell.DataCell, actualStyleId, state)
             : writer.TryWriteCell(cell.DataCell, actualStyleId, state.Buffer);
     }
 
@@ -50,7 +50,7 @@ internal sealed class CellWriter : ICellWriter<Cell>
     public bool TryWriteValue(in Cell cell, ref int valueIndex, CellWriterState state)
     {
         return cell.Formula is { } formula
-            ? FormulaCellHelper.FinishWritingFormulaCellValue(cell, formula.FormulaText, ref valueIndex, state.Buffer)
+            ? FormulaCellHelper.FinishWritingFormulaCellValue(cell, formula.GetFormulaText(state), ref valueIndex, state.Buffer)
             : CellValueWriter.GetWriter(cell.DataCell.Type).WriteValuePieceByPiece(cell.DataCell, state.Buffer, ref valueIndex);
     }
 

--- a/SpreadCheetah/Formula.cs
+++ b/SpreadCheetah/Formula.cs
@@ -1,3 +1,4 @@
+using SpreadCheetah.CellWriters;
 using SpreadCheetah.Formulas;
 
 namespace SpreadCheetah;
@@ -9,6 +10,8 @@ public readonly record struct Formula
 {
     internal string FormulaText { get; }
 
+    internal bool IsR1C1 { get; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="Formula"/> struct with a formula text.
     /// The formula text should be without a starting equal sign (=).
@@ -17,6 +20,28 @@ public readonly record struct Formula
     {
         FormulaText = formulaText ?? "";
     }
+
+    private Formula(string formulaText, bool isR1C1)
+    {
+        FormulaText = formulaText;
+        IsR1C1 = isR1C1;
+    }
+
+    /// <summary>
+    /// Creates a formula from text in the R1C1 reference style. References in the formula will be converted to the
+    /// A1 reference style (which is required in the XLSX file format) based on the position of the cell that the
+    /// formula is added to. This makes it possible to reuse the same formula for multiple cells.
+    /// The formula text should be without a starting equal sign (=).
+    /// </summary>
+    public static Formula R1C1(string formula)
+    {
+        ArgumentNullException.ThrowIfNull(formula);
+        return new Formula(formula, isR1C1: true);
+    }
+
+    internal string GetFormulaText(CellWriterState state) => IsR1C1
+        ? R1C1FormulaConverter.ToA1(FormulaText, (int)(state.NextRowIndex - 1), state.Column + 1)
+        : FormulaText;
 
     /// <summary>
     /// Creates a hyperlink formula that represents a link to the specified URI.

--- a/SpreadCheetah/Formulas/R1C1FormulaConverter.cs
+++ b/SpreadCheetah/Formulas/R1C1FormulaConverter.cs
@@ -1,0 +1,254 @@
+using SpreadCheetah.Helpers;
+using System.Globalization;
+using System.Text;
+
+namespace SpreadCheetah.Formulas;
+
+internal static class R1C1FormulaConverter
+{
+    private enum ReferenceKind
+    {
+        Cell,
+        WholeRow,
+        WholeColumn
+    }
+
+    /// <summary>
+    /// Converts a formula in the R1C1 reference style to the A1 reference style.
+    /// <paramref name="row"/> and <paramref name="column"/> are the 1-based position of the cell that the formula belongs to,
+    /// which is used as the anchor for relative references.
+    /// </summary>
+    public static string ToA1(string formula, int row, int column)
+    {
+        var sb = new StringBuilder(formula.Length);
+        var i = 0;
+        var n = formula.Length;
+
+        while (i < n)
+        {
+            var c = formula[i];
+
+            if (c is '"' or '\'')
+            {
+                i = AppendDelimited(formula, i, c, sb);
+                continue;
+            }
+
+            var leftBoundary = i == 0 || !IsWordChar(formula[i - 1]);
+            if (leftBoundary && c is 'R' or 'r' or 'C' or 'c'
+                && TryParseReference(formula, i, row, column, out var length, out var piece, out var kind))
+            {
+                var afterFirst = i + length;
+                var rightChar = afterFirst < n ? formula[afterFirst] : '\0';
+
+                // Combine into a range when followed by ':' and another reference.
+                if (rightChar == ':'
+                    && TryParseReference(formula, afterFirst + 1, row, column, out var length2, out var piece2, out _))
+                {
+                    var afterSecond = afterFirst + 1 + length2;
+                    var rightChar2 = afterSecond < n ? formula[afterSecond] : '\0';
+                    if (!IsWordChar(rightChar2) && rightChar2 is not ('[' or '!'))
+                    {
+                        sb.Append(piece).Append(':').Append(piece2);
+                        i = afterSecond;
+                        continue;
+                    }
+                }
+
+                if (!IsWordChar(rightChar) && rightChar is not ('[' or '!'))
+                {
+                    AppendStandalone(sb, piece, kind);
+                    i = afterFirst;
+                    continue;
+                }
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendStandalone(StringBuilder sb, string piece, ReferenceKind kind)
+    {
+        // A whole row or column reference in the A1 notation always has the form "X:X".
+        if (kind is ReferenceKind.Cell)
+            sb.Append(piece);
+        else
+            sb.Append(piece).Append(':').Append(piece);
+    }
+
+    // Appends a string literal ("...") or a quoted sheet name ('...'), including the surrounding delimiters.
+    // The delimiter can be escaped by doubling it.
+    private static int AppendDelimited(string s, int i, char delimiter, StringBuilder sb)
+    {
+        var n = s.Length;
+        sb.Append(s[i]);
+        i++;
+
+        while (i < n)
+        {
+            var c = s[i];
+            sb.Append(c);
+            i++;
+
+            if (c == delimiter)
+            {
+                if (i < n && s[i] == delimiter)
+                {
+                    sb.Append(delimiter);
+                    i++;
+                    continue;
+                }
+
+                break;
+            }
+        }
+
+        return i;
+    }
+
+    private static bool TryParseReference(string s, int start, int anchorRow, int anchorColumn, out int length, out string piece, out ReferenceKind kind)
+    {
+        length = 0;
+        piece = "";
+        kind = ReferenceKind.Cell;
+
+        var n = s.Length;
+        if (start >= n)
+            return false;
+
+        var j = start;
+        var c = s[j];
+
+        var hasRow = false;
+        var hasColumn = false;
+        bool rowRelative = true, columnRelative = true;
+        int rowValue = 0, columnValue = 0;
+
+        if (c is 'R' or 'r')
+        {
+            j++;
+            hasRow = true;
+            if (!TryParseAxis(s, ref j, out rowRelative, out rowValue))
+                return false;
+
+            if (j < n && s[j] is 'C' or 'c')
+            {
+                j++;
+                hasColumn = true;
+                if (!TryParseAxis(s, ref j, out columnRelative, out columnValue))
+                    return false;
+            }
+        }
+        else if (c is 'C' or 'c')
+        {
+            j++;
+            hasColumn = true;
+            if (!TryParseAxis(s, ref j, out columnRelative, out columnValue))
+                return false;
+        }
+        else
+        {
+            return false;
+        }
+
+        length = j - start;
+
+        if (hasRow && hasColumn)
+        {
+            kind = ReferenceKind.Cell;
+            piece = FormatColumn(columnRelative, columnValue, anchorColumn, s) + FormatRow(rowRelative, rowValue, anchorRow, s);
+        }
+        else if (hasRow)
+        {
+            kind = ReferenceKind.WholeRow;
+            piece = FormatRow(rowRelative, rowValue, anchorRow, s);
+        }
+        else
+        {
+            kind = ReferenceKind.WholeColumn;
+            piece = FormatColumn(columnRelative, columnValue, anchorColumn, s);
+        }
+
+        return true;
+    }
+
+    private static bool TryParseAxis(string s, ref int j, out bool relative, out int value)
+    {
+        var n = s.Length;
+        relative = true;
+        value = 0;
+
+        if (j < n && s[j] == '[')
+        {
+            j++;
+            var negative = false;
+            if (j < n && (s[j] == '-' || s[j] == '+'))
+            {
+                negative = s[j] == '-';
+                j++;
+            }
+
+            if (!TryReadNumber(s, ref j, out var offset))
+                return false;
+            if (j >= n || s[j] != ']')
+                return false;
+
+            j++;
+            value = negative ? -offset : offset;
+            return true;
+        }
+
+        if (j < n && IsAsciiDigit(s[j]))
+        {
+            TryReadNumber(s, ref j, out value);
+            relative = false;
+            return true;
+        }
+
+        return true;
+    }
+
+    private static bool TryReadNumber(string s, ref int j, out int value)
+    {
+        var n = s.Length;
+        var start = j;
+        long acc = 0;
+        while (j < n && IsAsciiDigit(s[j]))
+        {
+            acc = acc * 10 + (s[j] - '0');
+            if (acc > SpreadsheetConstants.MaxNumberOfRows)
+                acc = SpreadsheetConstants.MaxNumberOfRows + 1; // Cap to avoid overflow; will fail the bounds check.
+            j++;
+        }
+
+        value = (int)acc;
+        return j > start;
+    }
+
+    private static string FormatRow(bool relative, int value, int anchor, string formula)
+    {
+        var row = relative ? anchor + value : value;
+        if (row is < 1 or > SpreadsheetConstants.MaxNumberOfRows)
+            ThrowHelper.R1C1ReferenceOutOfBounds(formula);
+
+        var rowNumber = row.ToString(NumberFormatInfo.InvariantInfo);
+        return relative ? rowNumber : "$" + rowNumber;
+    }
+
+    private static string FormatColumn(bool relative, int value, int anchor, string formula)
+    {
+        var column = relative ? anchor + value : value;
+        if (column is < 1 or > SpreadsheetConstants.MaxNumberOfColumns)
+            ThrowHelper.R1C1ReferenceOutOfBounds(formula);
+
+        var columnName = SpreadsheetUtility.GetColumnName(column);
+        return relative ? columnName : "$" + columnName;
+    }
+
+    private static bool IsWordChar(char c) => char.IsLetterOrDigit(c) || c is '_' or '.';
+
+    private static bool IsAsciiDigit(char c) => (uint)(c - '0') <= 9;
+}

--- a/SpreadCheetah/Formulas/R1C1FormulaConverter.cs
+++ b/SpreadCheetah/Formulas/R1C1FormulaConverter.cs
@@ -1,5 +1,4 @@
 using SpreadCheetah.Helpers;
-using System.Globalization;
 using System.Text;
 
 namespace SpreadCheetah.Formulas;
@@ -11,6 +10,16 @@ internal static class R1C1FormulaConverter
         Cell,
         WholeRow,
         WholeColumn
+    }
+
+    private readonly struct ParsedReference(int length, ReferenceKind kind, bool rowRelative, int row, bool columnRelative, int column)
+    {
+        public int Length { get; } = length;
+        public ReferenceKind Kind { get; } = kind;
+        public bool RowRelative { get; } = rowRelative;
+        public int Row { get; } = row;
+        public bool ColumnRelative { get; } = columnRelative;
+        public int Column { get; } = column;
     }
 
     /// <summary>
@@ -36,20 +45,22 @@ internal static class R1C1FormulaConverter
 
             var leftBoundary = i == 0 || !IsWordChar(formula[i - 1]);
             if (leftBoundary && c is 'R' or 'r' or 'C' or 'c'
-                && TryParseReference(formula, i, row, column, out var length, out var piece, out var kind))
+                && TryParseReference(formula, i, row, column, out var first))
             {
-                var afterFirst = i + length;
+                var afterFirst = i + first.Length;
                 var rightChar = afterFirst < n ? formula[afterFirst] : '\0';
 
                 // Combine into a range when followed by ':' and another reference.
                 if (rightChar == ':'
-                    && TryParseReference(formula, afterFirst + 1, row, column, out var length2, out var piece2, out _))
+                    && TryParseReference(formula, afterFirst + 1, row, column, out var second))
                 {
-                    var afterSecond = afterFirst + 1 + length2;
+                    var afterSecond = afterFirst + 1 + second.Length;
                     var rightChar2 = afterSecond < n ? formula[afterSecond] : '\0';
                     if (!IsWordChar(rightChar2) && rightChar2 is not ('[' or '!'))
                     {
-                        sb.Append(piece).Append(':').Append(piece2);
+                        WriteReference(sb, first, selfDuplicate: false);
+                        sb.Append(':');
+                        WriteReference(sb, second, selfDuplicate: false);
                         i = afterSecond;
                         continue;
                     }
@@ -57,7 +68,7 @@ internal static class R1C1FormulaConverter
 
                 if (!IsWordChar(rightChar) && rightChar is not ('[' or '!'))
                 {
-                    AppendStandalone(sb, piece, kind);
+                    WriteReference(sb, first, selfDuplicate: true);
                     i = afterFirst;
                     continue;
                 }
@@ -70,13 +81,51 @@ internal static class R1C1FormulaConverter
         return sb.ToString();
     }
 
-    private static void AppendStandalone(StringBuilder sb, string piece, ReferenceKind kind)
+    private static void WriteReference(StringBuilder sb, in ParsedReference reference, bool selfDuplicate)
     {
-        // A whole row or column reference in the A1 notation always has the form "X:X".
-        if (kind is ReferenceKind.Cell)
-            sb.Append(piece);
-        else
-            sb.Append(piece).Append(':').Append(piece);
+        switch (reference.Kind)
+        {
+            case ReferenceKind.Cell:
+                WriteColumnPart(sb, reference);
+                WriteRowPart(sb, reference);
+                break;
+            case ReferenceKind.WholeRow:
+                // A whole row reference in the A1 notation has the form "5:5".
+                WriteRowPart(sb, reference);
+                if (selfDuplicate)
+                {
+                    sb.Append(':');
+                    WriteRowPart(sb, reference);
+                }
+
+                break;
+            default:
+                // A whole column reference in the A1 notation has the form "C:C".
+                WriteColumnPart(sb, reference);
+                if (selfDuplicate)
+                {
+                    sb.Append(':');
+                    WriteColumnPart(sb, reference);
+                }
+
+                break;
+        }
+    }
+
+    private static void WriteRowPart(StringBuilder sb, in ParsedReference reference)
+    {
+        if (!reference.RowRelative)
+            sb.Append('$');
+
+        sb.Append(reference.Row);
+    }
+
+    private static void WriteColumnPart(StringBuilder sb, in ParsedReference reference)
+    {
+        if (!reference.ColumnRelative)
+            sb.Append('$');
+
+        sb.Append(SpreadsheetUtility.GetColumnName(reference.Column));
     }
 
     // Appends a string literal ("...") or a quoted sheet name ('...'), including the surrounding delimiters.
@@ -109,11 +158,9 @@ internal static class R1C1FormulaConverter
         return i;
     }
 
-    private static bool TryParseReference(string s, int start, int anchorRow, int anchorColumn, out int length, out string piece, out ReferenceKind kind)
+    private static bool TryParseReference(string s, int start, int anchorRow, int anchorColumn, out ParsedReference reference)
     {
-        length = 0;
-        piece = "";
-        kind = ReferenceKind.Cell;
+        reference = default;
 
         var n = s.Length;
         if (start >= n)
@@ -154,24 +201,18 @@ internal static class R1C1FormulaConverter
             return false;
         }
 
-        length = j - start;
+        var length = j - start;
+        var kind = (hasRow, hasColumn) switch
+        {
+            (true, true) => ReferenceKind.Cell,
+            (true, false) => ReferenceKind.WholeRow,
+            _ => ReferenceKind.WholeColumn
+        };
 
-        if (hasRow && hasColumn)
-        {
-            kind = ReferenceKind.Cell;
-            piece = FormatColumn(columnRelative, columnValue, anchorColumn, s) + FormatRow(rowRelative, rowValue, anchorRow, s);
-        }
-        else if (hasRow)
-        {
-            kind = ReferenceKind.WholeRow;
-            piece = FormatRow(rowRelative, rowValue, anchorRow, s);
-        }
-        else
-        {
-            kind = ReferenceKind.WholeColumn;
-            piece = FormatColumn(columnRelative, columnValue, anchorColumn, s);
-        }
+        var row = hasRow ? Resolve(rowRelative, rowValue, anchorRow, SpreadsheetConstants.MaxNumberOfRows, s) : 0;
+        var column = hasColumn ? Resolve(columnRelative, columnValue, anchorColumn, SpreadsheetConstants.MaxNumberOfColumns, s) : 0;
 
+        reference = new ParsedReference(length, kind, rowRelative, row, columnRelative, column);
         return true;
     }
 
@@ -228,24 +269,13 @@ internal static class R1C1FormulaConverter
         return j > start;
     }
 
-    private static string FormatRow(bool relative, int value, int anchor, string formula)
+    private static int Resolve(bool relative, int value, int anchor, int max, string formula)
     {
-        var row = relative ? anchor + value : value;
-        if (row is < 1 or > SpreadsheetConstants.MaxNumberOfRows)
+        var result = relative ? anchor + value : value;
+        if (result < 1 || result > max)
             ThrowHelper.R1C1ReferenceOutOfBounds(formula);
 
-        var rowNumber = row.ToString(NumberFormatInfo.InvariantInfo);
-        return relative ? rowNumber : "$" + rowNumber;
-    }
-
-    private static string FormatColumn(bool relative, int value, int anchor, string formula)
-    {
-        var column = relative ? anchor + value : value;
-        if (column is < 1 or > SpreadsheetConstants.MaxNumberOfColumns)
-            ThrowHelper.R1C1ReferenceOutOfBounds(formula);
-
-        var columnName = SpreadsheetUtility.GetColumnName(column);
-        return relative ? columnName : "$" + columnName;
+        return result;
     }
 
     private static bool IsWordChar(char c) => char.IsLetterOrDigit(c) || c is '_' or '.';

--- a/SpreadCheetah/Helpers/ThrowHelper.cs
+++ b/SpreadCheetah/Helpers/ThrowHelper.cs
@@ -106,6 +106,10 @@ internal static class ThrowHelper
         => throw new ArgumentException($"Note text can not exceed {SpreadsheetConstants.MaxNoteTextLength} characters.", paramName);
 
     [DoesNotReturn]
+    public static void R1C1ReferenceOutOfBounds(string formula)
+        => throw new ArgumentException($"The R1C1 formula '{formula}' contains a reference that is outside the bounds of the worksheet.", nameof(formula));
+
+    [DoesNotReturn]
     public static void ResizeAndMoveCellsCombinationNotSupported(string resizeParamName, string moveParamName)
         => throw new ArgumentException($"Enabling {resizeParamName} is not supported when {moveParamName} is false.", resizeParamName);
 

--- a/SpreadCheetah/Helpers/ThrowHelper.cs
+++ b/SpreadCheetah/Helpers/ThrowHelper.cs
@@ -107,7 +107,7 @@ internal static class ThrowHelper
 
     [DoesNotReturn]
     public static void R1C1ReferenceOutOfBounds(string formula)
-        => throw new ArgumentException($"The R1C1 formula '{formula}' contains a reference that is outside the bounds of the worksheet.", nameof(formula));
+        => throw new SpreadCheetahException($"The R1C1 formula '{formula}' contains a reference that is outside the bounds of the worksheet when anchored to this cell.");
 
     [DoesNotReturn]
     public static void ResizeAndMoveCellsCombinationNotSupported(string resizeParamName, string moveParamName)


### PR DESCRIPTION
Adds the R1C1 support and tests for it. 

It should cover all the R1C1 use cases.  
Except for the "wrap": RC[-1] in A1 in excel will reference the most right column, wrapping the document. This is currently not supported to not complicate the logic for such rare usecase.

Closes #161 